### PR TITLE
Improve table styling options

### DIFF
--- a/markymark/src/main/java/com/moveagency/markymark/composer/DefaultMarkyMarkComposer.kt
+++ b/markymark/src/main/java/com/moveagency/markymark/composer/DefaultMarkyMarkComposer.kt
@@ -21,32 +21,12 @@ package com.moveagency.markymark.composer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
-import com.moveagency.markymark.composable.CodeBlock
-import com.moveagency.markymark.composable.Headline
-import com.moveagency.markymark.composable.Image
-import com.moveagency.markymark.composable.ListItem
-import com.moveagency.markymark.composable.Rule
-import com.moveagency.markymark.composable.TableBlock
-import com.moveagency.markymark.composable.TextNode
-import com.moveagency.markymark.composable.blockQuoteItem
+import com.moveagency.markymark.composable.*
 import com.moveagency.markymark.model.AnnotatedStableNode
-import com.moveagency.markymark.model.ComposableStableNode.BlockQuote
-import com.moveagency.markymark.model.ComposableStableNode.CodeBlock
-import com.moveagency.markymark.model.ComposableStableNode.Headline
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING1
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING2
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING3
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING4
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING5
-import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.HEADING6
-import com.moveagency.markymark.model.ComposableStableNode.Image
-import com.moveagency.markymark.model.ComposableStableNode.ListBlock
-import com.moveagency.markymark.model.ComposableStableNode.ListEntry
+import com.moveagency.markymark.model.ComposableStableNode.*
+import com.moveagency.markymark.model.ComposableStableNode.Headline.Level.*
 import com.moveagency.markymark.model.ComposableStableNode.ListEntry.ListItem
 import com.moveagency.markymark.model.ComposableStableNode.ListEntry.ListNode
-import com.moveagency.markymark.model.ComposableStableNode.Paragraph
-import com.moveagency.markymark.model.ComposableStableNode.Rule
-import com.moveagency.markymark.model.ComposableStableNode.TableBlock
 import com.moveagency.markymark.model.StableNode
 import com.moveagency.markymark.theme.ComposableStyles
 import com.moveagency.markymark.theme.ListBlockStyle
@@ -305,7 +285,7 @@ open class DefaultMarkyMarkComposer : MarkyMarkComposer {
         styles: ComposableStyles,
     ) = item(contentType = TableBlock::class.qualifiedName) {
         TableBlock(
-            modifier = modifier.fillParentMaxWidth(),
+            modifier = modifier,
             node = node,
             style = styles.tableBlock,
         )

--- a/markymark/src/main/java/com/moveagency/markymark/theme/MarkyMarkTheme.kt
+++ b/markymark/src/main/java/com/moveagency/markymark/theme/MarkyMarkTheme.kt
@@ -52,32 +52,15 @@ import com.moveagency.markymark.annotator.DefaultMarkyMarkAnnotator
 import com.moveagency.markymark.composer.DefaultMarkyMarkComposer
 import com.moveagency.markymark.composer.Padding
 import com.moveagency.markymark.model.AnnotatedStableNode
-import com.moveagency.markymark.model.AnnotatedStableNode.Bold
-import com.moveagency.markymark.model.AnnotatedStableNode.Code
-import com.moveagency.markymark.model.AnnotatedStableNode.Italic
-import com.moveagency.markymark.model.AnnotatedStableNode.Link
-import com.moveagency.markymark.model.AnnotatedStableNode.Strikethrough
-import com.moveagency.markymark.model.AnnotatedStableNode.Subscript
-import com.moveagency.markymark.model.AnnotatedStableNode.Superscript
+import com.moveagency.markymark.model.AnnotatedStableNode.*
 import com.moveagency.markymark.model.ComposableStableNode
-import com.moveagency.markymark.model.ComposableStableNode.BlockQuote
-import com.moveagency.markymark.model.ComposableStableNode.CodeBlock
-import com.moveagency.markymark.model.ComposableStableNode.Headline
-import com.moveagency.markymark.model.ComposableStableNode.Image
-import com.moveagency.markymark.model.ComposableStableNode.ListBlock
-import com.moveagency.markymark.model.ComposableStableNode.ListItemType
-import com.moveagency.markymark.model.ComposableStableNode.Paragraph
-import com.moveagency.markymark.model.ComposableStableNode.Rule
-import com.moveagency.markymark.model.ComposableStableNode.TableBlock
-import com.moveagency.markymark.model.ComposableStableNode.TableCell
+import com.moveagency.markymark.model.ComposableStableNode.*
 import com.moveagency.markymark.model.StableNode
 import com.moveagency.markymark.theme.ListItemStyle.Companion.DefaultListItemIndicatorPadding
 import com.moveagency.markymark.theme.ListItemStyle.Companion.DefaultListItemPadding
 import com.moveagency.markymark.theme.ListItemStyle.Companion.DefaultListItemTextStyle
 import com.moveagency.markymark.theme.TextNodeStyle.Companion.BodyTextStyle
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Oval
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Rectangle
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Triangle
+import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.*
 import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Style.Fill
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -238,26 +221,61 @@ data class BlockQuoteStyle(
  */
 @Immutable
 data class TableBlockStyle(
-    val padding: Padding = Padding(),
+    val padding: Padding = Padding(4.dp),
     val cellMinWidth: Dp = 0.dp,
     val cellMaxWidth: Dp = Dp.Infinity,
     val cellMinHeight: Dp = 0.dp,
     val cellMaxHeight: Dp = Dp.Infinity,
     val headerStyle: TableCellStyle = TableCellStyle(background = LightGray),
     val bodyStyle: TableCellStyle = TableCellStyle(background = Transparent),
-    val outlineStyle: TableDividerStyle = TableDividerStyle(
-        thickness = 3.dp,
-        color = Black,
+    val outlineDividerStyles: OutlineDividerStyles = OutlineDividerStyles(
+        all = TableDividerStyle(
+            thickness = 3.dp,
+            color = Black,
+        ),
     ),
     val headerDividerStyle: TableDividerStyle = TableDividerStyle(
         thickness = 2.dp,
         color = DarkGray,
     ),
-    val bodyDividerStyle: TableDividerStyle = TableDividerStyle(
-        thickness = 1.dp,
-        color = Gray,
+    val bodyDividerStyles: BodyDividerStyles = BodyDividerStyles(
+        all = TableDividerStyle(
+            thickness = 1.dp,
+            color = Gray,
+        ),
     ),
 )
+
+/**
+ * Theming attributes used when rendering the outline dividers of a table.
+ */
+@Immutable
+data class OutlineDividerStyles(
+    val left: TableDividerStyle = TableDividerStyle(),
+    val top: TableDividerStyle = TableDividerStyle(),
+    val right: TableDividerStyle = TableDividerStyle(),
+    val bottom: TableDividerStyle = TableDividerStyle(),
+) {
+
+    constructor(
+        horizontal: TableDividerStyle = TableDividerStyle(),
+        vertical: TableDividerStyle = TableDividerStyle(),
+    ) : this(left = horizontal, top = vertical, right = horizontal, bottom = vertical)
+
+    constructor(all: TableDividerStyle) : this(all, all, all, all)
+}
+
+/**
+ * Theming attributes used when rendering the body dividers of a table.
+ */
+@Immutable
+data class BodyDividerStyles(
+    val horizontal: TableDividerStyle = TableDividerStyle(),
+    val vertical: TableDividerStyle = TableDividerStyle(),
+) {
+
+    constructor(all: TableDividerStyle) : this(all, all)
+}
 
 /**
  * Theming attributes used when rendering [TableCell]s. [padding] is the spacing around the text of a cell but with the
@@ -267,7 +285,7 @@ data class TableBlockStyle(
 data class TableCellStyle(
     val padding: Padding = Padding(all = 4.dp),
     val textStyle: TextStyle = BodyTextStyle,
-    val background: Color,
+    val background: Color = Transparent,
 )
 
 /**
@@ -275,8 +293,8 @@ data class TableCellStyle(
  */
 @Immutable
 data class TableDividerStyle(
-    val thickness: Dp,
-    val color: Color,
+    val thickness: Dp = Dp.Unspecified,
+    val color: Color = Color.Unspecified,
 )
 
 /**

--- a/sample/src/main/java/com/moveagency/markymark/sample/ui/theme/Theme.kt
+++ b/sample/src/main/java/com/moveagency/markymark/sample/ui/theme/Theme.kt
@@ -20,16 +20,16 @@ package com.moveagency.markymark.sample.ui.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.Transparent
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontFamily.Companion.Monospace
 import androidx.compose.ui.text.font.FontStyle.Companion.Italic
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.moveagency.markymark.composer.Padding
 import com.moveagency.markymark.sample.ui.theme.ColorPalette.M2Black
 import com.moveagency.markymark.sample.ui.theme.ColorPalette.M2Blue
-import com.moveagency.markymark.sample.ui.theme.ColorPalette.M2Gray
 import com.moveagency.markymark.sample.ui.theme.ColorPalette.M2LightGray
 import com.moveagency.markymark.sample.ui.theme.ColorPalette.M2Orange
 import com.moveagency.markymark.sample.ui.theme.Typography.Body
@@ -39,29 +39,10 @@ import com.moveagency.markymark.sample.ui.theme.Typography.Heading3
 import com.moveagency.markymark.sample.ui.theme.Typography.Heading4
 import com.moveagency.markymark.sample.ui.theme.Typography.Heading5
 import com.moveagency.markymark.sample.ui.theme.Typography.Heading6
-import com.moveagency.markymark.theme.AnnotatedStyles
-import com.moveagency.markymark.theme.BlockQuoteStyle
-import com.moveagency.markymark.theme.CodeBlockStyle
-import com.moveagency.markymark.theme.ComposableStyles
-import com.moveagency.markymark.theme.HeadingLevelStyle
-import com.moveagency.markymark.theme.HeadingsStyle
-import com.moveagency.markymark.theme.ImageStyle
-import com.moveagency.markymark.theme.ListBlockStyle
-import com.moveagency.markymark.theme.LocalMarkyMarkTheme
-import com.moveagency.markymark.theme.MarkyMarkTheme
-import com.moveagency.markymark.theme.OrderedListItemStyle
-import com.moveagency.markymark.theme.RuleStyle
-import com.moveagency.markymark.theme.TableBlockStyle
-import com.moveagency.markymark.theme.TableCellStyle
-import com.moveagency.markymark.theme.TableDividerStyle
-import com.moveagency.markymark.theme.TaskListItemStyle
+import com.moveagency.markymark.theme.*
 import com.moveagency.markymark.theme.TaskListItemStyle.Tints
-import com.moveagency.markymark.theme.TextNodeStyle
-import com.moveagency.markymark.theme.UnorderedListItemStyle
 import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Oval
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Rectangle
-import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.Triangle
+import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Shape.*
 import com.moveagency.markymark.theme.UnorderedListItemStyle.Indicator.Style.Stroke
 import kotlinx.collections.immutable.persistentListOf
 
@@ -83,13 +64,21 @@ private val SampleMarkyMarkTheme = MarkyMarkTheme(
         ),
         blockQuote = BlockQuoteStyle(
             indicatorTint = M2Orange,
-            background = Color.Transparent,
+            background = Transparent,
         ),
         tableBlock = TableBlockStyle(
-            headerStyle = TableCellStyle(background = M2LightGray),
-            outlineStyle = TableDividerStyle(thickness = 3.dp, color = M2Black),
-            headerDividerStyle = TableDividerStyle(thickness = 2.dp, color = M2Orange),
-            bodyDividerStyle = TableDividerStyle(thickness = 1.dp, color = M2Gray),
+            padding = Padding(vertical = Spacing.x1),
+            headerStyle = TableCellStyle(
+                padding = Padding(),
+                textStyle = Heading5,
+            ),
+            bodyStyle = TableCellStyle(padding = Padding()),
+            outlineDividerStyles = OutlineDividerStyles(),
+            headerDividerStyle = TableDividerStyle(thickness = Spacing.x0_25),
+            bodyDividerStyles = BodyDividerStyles(
+                horizontal = TableDividerStyle(thickness = Spacing.x0_25),
+                vertical = TableDividerStyle(thickness = Spacing.x4),
+            )
         ),
         listBlock = ListBlockStyle(
             orderedStyle = OrderedListItemStyle(textStyle = Body),


### PR DESCRIPTION
- Added the ability to use `Dp.Unspecified` & `Color.Unspecified` for dividers
- Added more customisation options to the divider styling
  - Outline dividers have been split into each side
  - Body dividers have been split into horizontal and vertical
- Fixed single column tables having their cells horizontally centered
- Tweaked the sample table style to show new capabilities

<img width="200" alt="Screenshot 2022-11-05 at 1 18 22 am" src="https://user-images.githubusercontent.com/29642163/200092030-f1bb7939-9aa4-4924-a834-4b09586944d1.png"> <img width="200" alt="Screenshot 2022-11-05 at 1 18 27 am" src="https://user-images.githubusercontent.com/29642163/200092032-3c385930-40fc-4e62-bb30-92582c67479a.png">
